### PR TITLE
Convert videos to high quality GIFs

### DIFF
--- a/demos/video_to_gif.js
+++ b/demos/video_to_gif.js
@@ -1,0 +1,22 @@
+var jsffmpeg = require(__dirname + "/../index.js");
+
+var args = require('node-getopt').create([
+	["", "source=FILE", "source video"],
+	["", "target=FILE", "target image"],
+	["", "docker=CONTAINER", "docker"]
+]).bindHelp().parseSystem().options;
+
+jsffmpeg.ffmpeg_simple(args.source, {
+	output_type: "gif",
+	framerate: 12,
+	width: 480,
+	time_start: 0,
+	time_end: 2
+}, args.target, null, null, {
+	docker: args.docker,
+	test_ffmpeg: true
+}).success(function (data) {
+	console.log(data);
+}).error(function (error) {
+	console.log(error);
+});

--- a/src/ffmpeg-helpers.js
+++ b/src/ffmpeg-helpers.js
@@ -124,9 +124,9 @@ Scoped.require([
 			var args = [];
 			args.push("-filter_complex [0:v]");
 			if (options.framerate)
-				args.push(`fps=${options.framerate},`);
+				args.push("fps=" + options.framerate + ",");
 			if (options.width || options.height)
-				args.push(`scale=w=${options.width || -1}:h=${options.height || -1}:flags=lanczos,`);
+				args.push("scale=w=" + (options.width || -1) + ":h=" + (options.height || -1) + ":flags=lanczos,");
 			args.push("split[a][b];[a]palettegen[p];[b][p]paletteuse");
 			return args.join("");
 		},

--- a/src/ffmpeg-helpers.js
+++ b/src/ffmpeg-helpers.js
@@ -120,6 +120,17 @@ Scoped.require([
 			return args.join(" ");
 		},
 		
+		paramsHighQualityGif: function (options) {
+			var args = [];
+			args.push("-filter_complex [0:v]");
+			if (options.framerate)
+				args.push(`fps=${options.framerate},`);
+			if (options.width || options.height)
+				args.push(`scale=w=${options.width || -1}:h=${options.height || -1}:flags=lanczos,`);
+			args.push("split[a][b];[a]palettegen[p];[b][p]paletteuse");
+			return args.join("");
+		},
+		
 		parseProgress: function (progress, duration) {
 			var raw = {};
 			if (progress.frame)

--- a/src/ffmpeg-simple.js
+++ b/src/ffmpeg-simple.js
@@ -376,7 +376,7 @@ Scoped.require([
 
 					
 					// Video Filters
-					if (vfilters) {
+					if (vfilters && options.output_type !== "gif") {
 						args.push("-vf");
 						args.push(vfilters);
 					}
@@ -422,6 +422,13 @@ Scoped.require([
 					args.push(helpers.paramsVideoCodecUniversalConfig);
 					if (format && format.passes > 1)
 						passes = format.passes;
+				}
+				if (options.output_type === "gif") {
+					args.push(helpers.paramsHighQualityGif({
+						"width": options.width,
+						"height": options.height,
+						"framerate": options.framerate
+					}));
 				}
 				
 				

--- a/tests/tests/ffmpeg-simple-gif.js
+++ b/tests/tests/ffmpeg-simple-gif.js
@@ -1,0 +1,64 @@
+var ffmpeg = require(__dirname + "/../../index.js");
+var settings = require(__dirname + "/settings.js");
+
+var TEMP_GIF = __dirname + "/../../temp/output-test.gif";
+var VIDEO_FILE = __dirname + "/../assets/video-640-360.mp4";
+
+QUnit.test("ffmpeg-simple gif transcoding", function(assert) {
+	var done = assert.async();
+	ffmpeg.ffmpeg_simple(VIDEO_FILE, {
+		output_type: "gif"
+	}, TEMP_GIF, null, null, settings).callback(function (error, value) {
+		assert.ok(!error);
+		done();
+	});
+});
+
+QUnit.test("ffmpeg-simple gif with 12 fps", function(assert) {
+	var done = assert.async();
+	ffmpeg.ffmpeg_simple(VIDEO_FILE, {
+        output_type: "gif",
+        framerate: 12
+	}, TEMP_GIF, null, null, settings).callback(function (error, value) {
+        assert.ok(!error);
+        assert.equal(value.video.frames, 12);
+		done();
+	});
+});
+
+QUnit.test("ffmpeg-simple gif with 320 width", function(assert) {
+	var done = assert.async();
+	ffmpeg.ffmpeg_simple(VIDEO_FILE, {
+        output_type: "gif",
+        width: 320
+	}, TEMP_GIF, null, null, settings).callback(function (error, value) {
+        assert.ok(!error);
+        assert.equal(value.video.width, 320);
+		done();
+	});
+});
+
+QUnit.test("ffmpeg-simple gif with 240 height", function(assert) {
+	var done = assert.async();
+	ffmpeg.ffmpeg_simple(VIDEO_FILE, {
+        output_type: "gif",
+        height: 240
+	}, TEMP_GIF, null, null, settings).callback(function (error, value) {
+        assert.ok(!error);
+        assert.equal(value.video.height, 240);
+		done();
+	});
+});
+
+QUnit.test("ffmpeg-simple gif with 0.8 second duration", function(assert) {
+	var done = assert.async();
+	ffmpeg.ffmpeg_simple(VIDEO_FILE, {
+        output_type: "gif",
+        time_end: 0.8
+	}, TEMP_GIF, null, null, settings).callback(function (error, value) {
+        assert.ok(!error);
+        assert.equal(value.duration, 0.8);
+		done();
+	});
+});
+


### PR DESCRIPTION
js-ffmpeg was already able to convert video to GIF, this PR allows conversion to higher quality GIFs.

For higher quality set `output_type:"gif"`.
```javascript
ffmpeg.ffmpeg("video.mp4", {
	output_type: "gif",
	...
}, "output.gif", function (progress) {
	console.log(progress);
}).success(function (json) {
	console.log(json);
}).error(function (error) {
	console.log(error);
});
```