### PR TITLE
Update JSHint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,7 @@ module.exports = function(grunt) {
 		},
 		jshint : {
 			options : {
-				es5 : false,
-				es3 : true
+				esversion: 6
 			},
 			source : [ "./Gruntfile.js", "./index.js", "./tests/tests/*.js",
 					"./src/*.js" ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "main": "index.js",
     "devDependencies": {
         "grunt": "^1.0.1",
-        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-jshint": "^3.0.0",
         "grunt-shell": "^2.1.0",
         "qunitjs": "^2.4.1"
     },


### PR DESCRIPTION
JSHint was failing due to usage of ES6 syntax. Since this repo runs on the server side and there's no need to worry about browser compatibility I'm updating it to allow ES6 syntax.

Also updated `grunt-contrib-jshint` version because the one we were using was throwing false syntax errors, like this one:
```
newArgs.push(...`-vf scale=w=${width}:h=${height}:force_original_aspect_ratio=decrease`.split(" "));
                ^ Expected an identifier and instead saw '-vf scale=w=${'.
```