### PR TITLE
Video trimming

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
         "docker-polyfill": "~0.0.1",
         "node-getopt": "^0.3.2",
         "tmp": "0.0.33"
+    },
+    "scripts": {
+        "test": "qunit tests/tests/*.js"
     }
 }

--- a/src/ffmpeg-helpers.js
+++ b/src/ffmpeg-helpers.js
@@ -74,7 +74,7 @@ Scoped.require([
 				args.push(this.formatTimeCode(time_start));
 			}
 			if (time_end) {
-				args.push("-t");
+				args.push("-to");
 				args.push(this.formatTimeCode(time_end));
 			}
 			if (time_limit)  {


### PR DESCRIPTION
`time_end` was setting video duration instead of exact time when video should end. For setting duration one should use `time_limit`.